### PR TITLE
Add `grad_transform` option to Metrics

### DIFF
--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -1,6 +1,5 @@
-from functools import partial
-
-from gradient_metrics import GradientMetricCollector, metrics
+from gradient_metrics import GradientMetricCollector
+from gradient_metrics.metrics import Max, Min, PNorm
 import torch
 import torch.nn as nn
 
@@ -57,12 +56,20 @@ if __name__ == "__main__":
     # the feature extractor and the fully connected part
     # We use Max, Min and PNorm with p=2
     mcollector = GradientMetricCollector(
-        (net, net.features, net.fc),
-        (
-            metrics.Max,
-            metrics.Min,
-            partial(metrics.PNorm, p=2),
-        ),
+        [
+            # Extract metrics from the whole network
+            Max(net),
+            Min(net),
+            PNorm(net, p=2),
+            # Extract metrics from the feature extraction part
+            Max(net.features),
+            Min(net.features),
+            PNorm(net.features, p=2),
+            # Extract metrics from the fully connected part
+            Max(net.fc),
+            Min(net.fc),
+            PNorm(net.fc, p=2),
+        ]
     )
 
     # predict the dummy data

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -91,3 +91,17 @@ if __name__ == "__main__":
     # 3 metrics over the feature part
     # 3 metrics over the fully connected part
     print(f"Shape of the gradient metric output: {grad_metrics.shape}")
+
+    # Now let's say we want to have the minimum and maximum of the absolute gradient
+    # values in the first convolution's kernel. We can achieve that by using a
+    # `grad_transform`:
+    mcollector = GradientMetricCollector(
+        [
+            Min(net.features[0].weight, grad_transform=lambda grad: grad.abs()),
+            Max(net.features[0].weight, grad_transform=lambda grad: grad.abs()),
+        ]
+    )
+
+    grad_metrics = mcollector(loss)
+
+    print(f"Value range of absolute gradient values:\n{grad_metrics}")

--- a/gradient_metrics/general.py
+++ b/gradient_metrics/general.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Set, Union
+from typing import List, Sequence, Union
 
 from gradient_metrics.metrics import GradientMetric
 import torch
@@ -30,11 +30,13 @@ class GradientMetricCollector(object):
         self.metrics = (
             tuple(metrics) if isinstance(metrics, (list, tuple)) else (metrics,)
         )
-        self.target_layers: Set[Union[nn.Module, torch.Tensor]] = set()
+        self.target_layers: List[Union[nn.Module, torch.Tensor]] = []
 
         # collect all parameters for zeroing gradients
+        t_layers = set()
         for m in self.metrics:
-            self.target_layers.update(m.target_layers)
+            t_layers.update(m.target_layers)
+        self.target_layers = list(t_layers)
 
         if len(self.metrics) == 0:
             raise ValueError("No metrics specified!")

--- a/gradient_metrics/general.py
+++ b/gradient_metrics/general.py
@@ -13,15 +13,8 @@ class GradientMetricCollector(object):
         """Helper class for computing gradients.
 
         Args:
-            target_layers (torch.nn.Module, torch.Tensor or sequence of them): Layers
-                or tensors on which the metrics will be registered as backward hooks.
-                For ``torch.nn.Module`` instances a single metric instance will be
-                registered to all parameters returned by
-                ``torch.nn.Module.parameters()``, thus computing the metric over all
-                parameters of the Module.
-            metrics (Type[GradientMetric] or sequence of Type[GradientMetric]):
-                A list of metric types to use. Each parameter from ``target_layers``
-                will register all of these metrics as backward hooks.
+            metrics (sequence of GradientMetric or GradientMetric):
+                A list of gradient metrics.
 
         Raises:
             ValueError: If the list of metrics is empty.

--- a/gradient_metrics/metrics.py
+++ b/gradient_metrics/metrics.py
@@ -13,6 +13,20 @@ class GradientMetric(object):
         ],
         grad_transform: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
     ) -> None:
+        """This is the base class for all gradient metrics
+
+        Args:
+            target_layers (torch.nn.Module, torch.Tensor or sequence of them): Layers
+                or tensors on which the metrics will be registered as backward hooks.
+                For ``torch.nn.Module`` instances a single metric instance will be
+                registered to all parameters returned by
+                ``torch.nn.Module.parameters()``, thus computing the metric over all
+                parameters of the Module.
+            grad_transform (Optional[Callable[[torch.Tensor], torch.Tensor]], optional):
+                A callable which accepts a ``torch.Tensor`` as input and returns a
+                ``torch.Tensor``. The callable is applied to the gradient before it is
+                handed over to the ``_collect`` method of a ``GradientMetric`` instance.
+        """
         self.hook_handles: List[RemovableHandle] = []
         self.target_layers = (
             (target_layers,)
@@ -108,6 +122,16 @@ class PNorm(GradientMetric):
             (\sum_{i=1}^n |x_i|^p)^{\frac{1}{p}}
 
         Args:
+            target_layers (torch.nn.Module, torch.Tensor or sequence of them): Layers
+                or tensors on which the metrics will be registered as backward hooks.
+                For ``torch.nn.Module`` instances a single metric instance will be
+                registered to all parameters returned by
+                ``torch.nn.Module.parameters()``, thus computing the metric over all
+                parameters of the Module.
+            grad_transform (Optional[Callable[[torch.Tensor], torch.Tensor]], optional):
+                A callable which accepts a ``torch.Tensor`` as input and returns a
+                ``torch.Tensor``. The callable is applied to the gradient before it is
+                handed over to the ``_collect`` method of a ``GradientMetric`` instance.
             p (int, optional): Power of the norm. Defaults to 1 (absolute-value norm).
             eps (float, optional): Small epsilon for gradients with very small vector
                 norms which would otherwise result in a possible division by zero in
@@ -148,12 +172,6 @@ class PNorm(GradientMetric):
 
 
 class Min(GradientMetric):
-    """Computes the minimum over the gradients.
-
-    The minimum between the currently saved buffer and the supplied gradients is
-    computed on each call, overwriting the buffer with the result.
-    """
-
     def __init__(
         self,
         target_layers: Union[
@@ -161,6 +179,23 @@ class Min(GradientMetric):
         ],
         grad_transform: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
     ) -> None:
+        """Computes the minimum over the gradients.
+
+        The minimum between the currently saved buffer and the supplied gradients is
+        computed on each call, overwriting the buffer with the result.
+
+        Args:
+            target_layers (torch.nn.Module, torch.Tensor or sequence of them): Layers
+                or tensors on which the metrics will be registered as backward hooks.
+                For ``torch.nn.Module`` instances a single metric instance will be
+                registered to all parameters returned by
+                ``torch.nn.Module.parameters()``, thus computing the metric over all
+                parameters of the Module.
+            grad_transform (Optional[Callable[[torch.Tensor], torch.Tensor]], optional):
+                A callable which accepts a ``torch.Tensor`` as input and returns a
+                ``torch.Tensor``. The callable is applied to the gradient before it is
+                handed over to the ``_collect`` method of a ``GradientMetric`` instance.
+        """
         super().__init__(target_layers=target_layers, grad_transform=grad_transform)
         self._metric_buffer: torch.Tensor
         self.reset()
@@ -179,12 +214,6 @@ class Min(GradientMetric):
 
 
 class Max(GradientMetric):
-    """Computes the maximum over the gradients.
-
-    The maximum between the currently saved buffer and the supplied gradients is
-    computed on each call, saving the result in the buffer.
-    """
-
     def __init__(
         self,
         target_layers: Union[
@@ -192,6 +221,23 @@ class Max(GradientMetric):
         ],
         grad_transform: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
     ) -> None:
+        """Computes the maximum over the gradients.
+
+        The maximum between the currently saved buffer and the supplied gradients is
+        computed on each call, saving the result in the buffer.
+
+        Args:
+            target_layers (torch.nn.Module, torch.Tensor or sequence of them): Layers
+                or tensors on which the metrics will be registered as backward hooks.
+                For ``torch.nn.Module`` instances a single metric instance will be
+                registered to all parameters returned by
+                ``torch.nn.Module.parameters()``, thus computing the metric over all
+                parameters of the Module.
+            grad_transform (Optional[Callable[[torch.Tensor], torch.Tensor]], optional):
+                A callable which accepts a ``torch.Tensor`` as input and returns a
+                ``torch.Tensor``. The callable is applied to the gradient before it is
+                handed over to the ``_collect`` method of a ``GradientMetric`` instance.
+        """
         super().__init__(target_layers=target_layers, grad_transform=grad_transform)
         self._metric_buffer: torch.Tensor
         self.reset()
@@ -210,13 +256,6 @@ class Max(GradientMetric):
 
 
 class Mean(GradientMetric):
-    """Computes the mean of the supplied gradients.
-
-    The buffer always holds the mean of all previously supplied gradients.
-    This exists besides :class:`~gradient_metrics.metrics.MeanStd` to reduce
-    computation cost if you do not want to computed the standard deviation.
-    """
-
     def __init__(
         self,
         target_layers: Union[
@@ -224,6 +263,24 @@ class Mean(GradientMetric):
         ],
         grad_transform: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
     ) -> None:
+        """Computes the mean of the supplied gradients.
+
+        The buffer always holds the mean of all previously supplied gradients.
+        This exists besides :class:`~gradient_metrics.metrics.MeanStd` to reduce
+        computation cost if you do not want to computed the standard deviation.
+
+        Args:
+            target_layers (torch.nn.Module, torch.Tensor or sequence of them): Layers
+                or tensors on which the metrics will be registered as backward hooks.
+                For ``torch.nn.Module`` instances a single metric instance will be
+                registered to all parameters returned by
+                ``torch.nn.Module.parameters()``, thus computing the metric over all
+                parameters of the Module.
+            grad_transform (Optional[Callable[[torch.Tensor], torch.Tensor]], optional):
+                A callable which accepts a ``torch.Tensor`` as input and returns a
+                ``torch.Tensor``. The callable is applied to the gradient before it is
+                handed over to the ``_collect`` method of a ``GradientMetric`` instance.
+        """
         super().__init__(target_layers=target_layers, grad_transform=grad_transform)
         self._metric_buffer: torch.Tensor
         self._count: int
@@ -267,6 +324,16 @@ class MeanStd(GradientMetric):
         is equal to ``eps``. This is also the lower bound for the standard deviation.
 
         Args:
+            target_layers (torch.nn.Module, torch.Tensor or sequence of them): Layers
+                or tensors on which the metrics will be registered as backward hooks.
+                For ``torch.nn.Module`` instances a single metric instance will be
+                registered to all parameters returned by
+                ``torch.nn.Module.parameters()``, thus computing the metric over all
+                parameters of the Module.
+            grad_transform (Optional[Callable[[torch.Tensor], torch.Tensor]], optional):
+                A callable which accepts a ``torch.Tensor`` as input and returns a
+                ``torch.Tensor``. The callable is applied to the gradient before it is
+                handed over to the ``_collect`` method of a ``GradientMetric`` instance.
             return_mean (bool, optional): Whether to return the mean or not.
                 Defaults to True.
             eps (float, optional): Small epsilon for gradients with very small standard

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -52,6 +52,11 @@ def test_max():
     loss.backward()
     assert metric.data == torch.tensor(2.0)
 
+    metric = Max(parameter, grad_transform=lambda grad: torch.tensor(-1.0))
+    loss = parameter * torch.tensor(2.0)
+    loss.backward()
+    assert metric.data == torch.tensor(-1.0)
+
 
 def test_min():
     parameter = torch.ones((1,), requires_grad=True)
@@ -74,6 +79,11 @@ def test_min():
     loss.backward()
     assert metric.data == torch.tensor(0.0)
 
+    metric = Min(parameter, grad_transform=lambda grad: torch.tensor(100.0))
+    loss = parameter * torch.tensor(0.0)
+    loss.backward()
+    assert metric.data == torch.tensor(100.0)
+
 
 def test_pnorm():
     parameter = torch.ones((3,), requires_grad=True)
@@ -82,6 +92,16 @@ def test_pnorm():
     loss = (parameter * torch.ones_like(parameter)).sum()
     loss.backward()
     assert metric.data == torch.tensor(3.0)
+
+    metric = PNorm(parameter, grad_transform=lambda grad: torch.tensor(100.0))
+    loss = (parameter * torch.tensor(0.0)).sum()
+    loss.backward()
+    assert metric.data == torch.tensor(100.0)
+
+    metric = PNorm(parameter, grad_transform=lambda grad: torch.tensor([100, 100]), p=2)
+    loss = (parameter * torch.tensor(1.0)).sum()
+    loss.backward()
+    assert metric.data == torch.tensor(20000**0.5)
 
 
 def test_mean():
@@ -100,6 +120,11 @@ def test_mean():
     loss = (parameter * torch.tensor([-1.0, 0.0, 1.0])).sum()
     loss.backward()
     assert metric.data == torch.tensor(0.0)
+
+    metric = Mean(parameter, grad_transform=lambda grad: torch.tensor(1))
+    loss = (parameter * torch.tensor(0.0)).sum()
+    loss.backward()
+    assert metric.data == torch.tensor(1)
 
 
 def test_meanstd():
@@ -128,3 +153,8 @@ def test_meanstd():
     loss = parameter * torch.tensor(2.0)
     loss.backward()
     assert metric.data == torch.tensor(eps)
+
+    metric = MeanStd(parameter, grad_transform=lambda grad: torch.tensor(1))
+    loss = (parameter * torch.tensor(0.0)).sum()
+    loss.backward()
+    assert torch.all(metric.data == torch.tensor([1, eps]))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,5 @@
+import gc
+
 from gradient_metrics.metrics import GradientMetric, Max, Mean, MeanStd, Min, PNorm
 import pytest
 import torch
@@ -7,7 +9,7 @@ def test_baseclass():
     class TestMetric(GradientMetric):
         pass
 
-    metric = TestMetric()
+    metric = TestMetric([])
 
     with pytest.raises(NotImplementedError):
         metric._collect(torch.ones((1,)))
@@ -19,10 +21,24 @@ def test_baseclass():
         metric.reset()
 
 
+@pytest.mark.parametrize(
+    ["metric_class", "kwargs", "error_type"],
+    [
+        (PNorm, dict(p=float("inf")), ValueError),
+        (PNorm, dict(eps=-1.0), ValueError),
+        (PNorm, dict(eps=0.0), ValueError),
+        (MeanStd, dict(eps=-1.0), ValueError),
+        (MeanStd, dict(eps=0.0), ValueError),
+    ],
+)
+def test_inputs(metric_class, kwargs, error_type):
+    with pytest.raises(error_type):
+        metric_class([], **kwargs)
+
+
 def test_max():
-    metric = Max()
     parameter = torch.ones((1,), requires_grad=True)
-    parameter.register_hook(metric)
+    metric = Max(parameter)
 
     loss = parameter * torch.ones((1,))
     loss.backward()
@@ -38,9 +54,8 @@ def test_max():
 
 
 def test_min():
-    metric = Min()
     parameter = torch.ones((1,), requires_grad=True)
-    parameter.register_hook(metric)
+    metric = Min(parameter)
 
     loss = parameter * torch.ones((1,))
     loss.backward()
@@ -60,21 +75,9 @@ def test_min():
     assert metric.data == torch.tensor(0.0)
 
 
-def test_pnorm_inputs():
-    with pytest.raises(ValueError):
-        PNorm(p=float("inf"))
-
-    with pytest.raises(ValueError):
-        PNorm(eps=-1.0)
-
-    with pytest.raises(ValueError):
-        PNorm(eps=0.0)
-
-
 def test_pnorm():
-    metric = PNorm()
     parameter = torch.ones((3,), requires_grad=True)
-    parameter.register_hook(metric)
+    metric = PNorm(parameter)
 
     loss = (parameter * torch.ones_like(parameter)).sum()
     loss.backward()
@@ -82,9 +85,8 @@ def test_pnorm():
 
 
 def test_mean():
-    metric = Mean()
     parameter = torch.ones((3,), requires_grad=True)
-    parameter.register_hook(metric)
+    metric = Mean(parameter)
 
     loss = (parameter * torch.ones_like(parameter)).sum()
     loss.backward()
@@ -100,36 +102,28 @@ def test_mean():
     assert metric.data == torch.tensor(0.0)
 
 
-def test_meanstd_inputs():
-    with pytest.raises(ValueError):
-        MeanStd(eps=-1.0)
-
-    with pytest.raises(ValueError):
-        MeanStd(eps=0.0)
-
-
 def test_meanstd():
     eps = 1e-16
-    metric = MeanStd(eps=eps)
     parameter = torch.ones((3,), requires_grad=True)
-    handle = parameter.register_hook(metric)
+    metric = MeanStd(parameter, eps=eps)
 
     loss = (parameter * torch.ones_like(parameter)).sum()
     loss.backward()
     assert torch.all(metric.data == torch.tensor([1.0, eps]))
     metric.reset()
-    handle.remove()
+    del metric
+    gc.collect()
 
     parameter = torch.ones((1,), requires_grad=True)
-    handle = parameter.register_hook(metric)
+    metric = MeanStd(parameter, eps=eps)
 
     loss = parameter * torch.tensor(0.0)
     loss.backward()
     assert torch.all(metric.data == torch.tensor([0.0, eps]))
-    handle.remove()
+    del metric
+    gc.collect()
 
-    metric = MeanStd(return_mean=False, eps=eps)
-    parameter.register_hook(metric)
+    metric = MeanStd(parameter, return_mean=False, eps=eps)
 
     loss = parameter * torch.tensor(2.0)
     loss.backward()


### PR DESCRIPTION
Added a `grad_transform` option to the `GradientMetric`. Additionally the `target_layers` option has been moved from `GradientMetricCollector` to `GradientMetric`. This allows to use the metrics standalone without having to initialize the metric collector.