### PR TITLE
Change python version used in workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -33,7 +33,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/publish-to-testpypi.yml
+++ b/.github/workflows/publish-to-testpypi.yml
@@ -33,7 +33,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1


### PR DESCRIPTION
As we have a minimal python version of 3.7 in `pyproject.toml`, code
should also be tested with it.
In the future we might want to add a tox setup to test with multiple
python versions.
